### PR TITLE
(Update) Adding new dependencies and making the script less verbose

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,7 @@ Installer for the [UNIT3D-Community-Edition](https://github.com/HDInnovations/UN
 
 **To install run the following:** (and follow the instructions. must be a fresh deicated server with nothing on it besides supported OS. Also must have a proper valid domain pointing to your server IP via A RECORD and CNAME for www)
 ```
+sudo apt -y install git
 git clone https://github.com/HDInnovations/UNIT3D-Installer.git installer
 cd installer
 sudo ./install.sh

--- a/src/Configs/os.php
+++ b/src/Configs/os.php
@@ -24,6 +24,7 @@ return [
             'zip' => 'Compress Files',
             'unzip' => 'Decompress Files',
             'htop' => 'Monitor Server Resources',
+            'cron' => 'Process Scheduling Daemon',
         ],
     ]
 

--- a/ubuntu.sh
+++ b/ubuntu.sh
@@ -1,5 +1,6 @@
 #!/usr/bin/env bash
 export DEBIAN_FRONTEND=noninteractive
+export DEBCONF_NOWARNINGS=yes
 
 source tools/colors.sh
 
@@ -14,7 +15,7 @@ check_locale() {
     echo -e "\n$Cyan Setting UTF8 ...$Color_Off"
 
     apt-get -qq update
-    apt-get install -qq language-pack-en-base > /dev/null
+    apt-get install -qq apt-utils language-pack-en-base > /dev/null
     export LC_ALL=en_US.UTF-8
     export LANG=en_US.UTF-8
     apt-get install -qq software-properties-common > /dev/null
@@ -55,8 +56,8 @@ add_pkgs() {
     # Redis
     echo -e "\n$Cyan Installing Redis ... $Color_Off"
 
-    curl -fsSL https://packages.redis.io/gpg | sudo gpg --dearmor -o /usr/share/keyrings/redis-archive-keyring.gpg
-    echo "deb [signed-by=/usr/share/keyrings/redis-archive-keyring.gpg] https://packages.redis.io/deb $(lsb_release -cs) main" | sudo tee /etc/apt/sources.list.d/redis.list
+    curl -fsSL https://packages.redis.io/gpg | sudo gpg --yes --dearmor -o /usr/share/keyrings/redis-archive-keyring.gpg
+    echo "deb [signed-by=/usr/share/keyrings/redis-archive-keyring.gpg] https://packages.redis.io/deb $(lsb_release -cs) main" | sudo tee /etc/apt/sources.list.d/redis.list > /dev/null
     apt-get -qq update > /dev/null
     apt-get -qq install redis > /dev/null
 
@@ -65,9 +66,8 @@ add_pkgs() {
     # Symlink Redis and Enable
     echo -e "\n$Cyan Symlink and Enabling Redis ... $Color_Off"
 
-    systemctl enable redis-server
-
-    echo -e "$IGreen OK $Color_Off"
+    systemctl -q enable --now redis-server
+    systemctl is-active --quiet redis-server && echo -e "$IGreen OK $Color_Off"||echo -e "$IRed NOK $Color_Off"
 
     # PHP Redis
     echo -e "\n$Cyan Installing PHP Redis ... $Color_Off"
@@ -87,7 +87,7 @@ add_pkgs() {
     echo -e "\n$Cyan Installing Bun ... $Color_Off"
 
     apt-get -qq install unzip > /dev/null
-    curl -fsSL https://bun.sh/install | bash
+    curl -fsSL https://bun.sh/install | bash >/dev/null 2>&1
     mv /root/.bun/bin/bun /usr/local/bin/
     chmod a+x /usr/local/bin/bun
     . ~/.bashrc


### PR DESCRIPTION
Added crontab to the dependencies list since it's not available on Ubuntu 22.04.4 LTS minimized by default, which causes the error below:
```
crontab -l ; echo "* * * * * php /var/www/html/artisan schedule:run >> /dev/null 2>&1") | crontab -
[============================] (Done!)
                                                                                                          
 [ERROR] sh: 1: crontab: not found                                                                        
         sh: 1: crontab: not found         
```                    

Export the variable `DEBCONF_NOWARNINGS=yes` to hide the errors below and also install `apt-utils`
```
apt-get install -qq language-pack-en-base
debconf: delaying package configuration, since apt-utils is not installed

Installing PHP ... 
debconf: delaying package configuration, since apt-utils is not installed
```

Other changes to make the installation less verbose.

The error below could not be removed because after installing `language-pack-en-base` you need to open a new console before exporting `LC_ALL=en_US.UTF-8` (I'm not really sure if that variable is necessary)

`-bash: warning: setlocale: LC_ALL: cannot change locale (en_US.UTF-8): No such file or directory `